### PR TITLE
Fix Linux build: missing X11 dep + Qt6 GLX API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,8 @@ elseif (APPLE)
   list(APPEND OLIVE_LIBRARIES "-framework IOKit")
 elseif(UNIX)
   list(APPEND OLIVE_LIBRARIES Qt6::DBus)
+  find_package(X11 REQUIRED)
+  list(APPEND OLIVE_LIBRARIES X11::X11)
 endif()
 
 # Generate Git hash

--- a/app/render/opengl/platformglcontext.cpp
+++ b/app/render/opengl/platformglcontext.cpp
@@ -95,7 +95,7 @@ bool PlatformGLContext::Create(QOpenGLContext *share_with, const QSurfaceFormat 
     // Create context
     GLXContext share_ctx = None;
     if (share_with) {
-        share_ctx = reinterpret_cast<GLXContext>(share_with->nativeInterface<QNativeInterface::QGLXContext>()->context());
+        share_ctx = share_with->nativeInterface<QNativeInterface::QGLXContext>()->nativeContext();
     }
 
     // Try to create context with version


### PR DESCRIPTION
Fixes #7

Tried to build on Arch, hit two issues:

- Missing `X11::X11` in link deps — linker errors on X11 symbols
- `QGLXContext::context()` doesn't exist in Qt6, replaced with `nativeContext()`

Builds clean after that (550/550, just one unused variable warning in previewautocacher.cpp).

I've always loved Olive 0.1, wanted to try this, didnt understand anything, the build is 300mb whereas 0.1 is 1.5, i'm making this pr and never coming back here. 
Made my own fork for 0.1 instead https://github.com/baptisterajaut/amber
have a great day.