### PR TITLE
fix(core): fix memory alignment bug causing crash on odd-sized images

### DIFF
--- a/app/codec/frame.cpp
+++ b/app/codec/frame.cpp
@@ -90,9 +90,9 @@ FramePtr Frame::Interlace(FramePtr top, FramePtr bottom)
 int Frame::generate_linesize_bytes(int width, PixelFormat format,
 								   int channel_count)
 {
-	// Align to 32 bytes (not sure if this is necessary?)
-	return VideoParams::GetBytesPerPixel(format, channel_count) *
-		   ((width + 31) & ~31);
+	// Calculate the raw bytes required for the image row  and Align to a multiple of 4 bytes.
+    int row_bytes = VideoParams::GetBytesPerPixel(format, channel_count) * width;
+    return (row_bytes + 3) & ~3;
 }
 
 Color Frame::get_pixel(int x, int y) const


### PR DESCRIPTION
- Replaced pixel-based 32-pixel stride alignment with a byte-based 4-byte alignment in generate_linesize_bytes.
- Fixed image distortion (diagonal tearing) and subsequent buffer overflow crashes when importing images with non-standard or odd widths.


### Problem
When importing images (like `.bmp` or `.png`) with non-standard or odd widths (e.g., 1003px), the preview display showed severe diagonal tearing/distortion, and the application would eventually freeze or crash. 

This happened because `Frame::generate_linesize_bytes` was artificially aligning the **pixel width** to a multiple of 32 `((width + 31) & ~31)`. This created a massive mismatch with external libraries like `OpenImageIO`, which read the exact raw pixels. The resulting stride mismatch caused rows to shift diagonally and led to a buffer overflow when rendering.

### Solution
Switched the alignment logic from **pixels** to **bytes** (which is the correct approach for hardware/GPU memory padding):
1. Calculate the raw row size in bytes first.
2. Align the final byte count to a 4-byte boundary `(row_bytes + 3) & ~3` to keep the GPU happy and match industry standards.

This fully resolves the distortion and eliminates the application freeze when working with arbitrary image resolutions.
